### PR TITLE
Addresses JNDI EJB names in KieReleaseIdXProcessInstanceListener, now,

### DIFF
--- a/jbpm-ee-services/src/main/java/org/jbpm/ee/services/ejb/startup/RuntimeManagerBean.java
+++ b/jbpm-ee-services/src/main/java/org/jbpm/ee/services/ejb/startup/RuntimeManagerBean.java
@@ -72,7 +72,7 @@ public class RuntimeManagerBean {
 
 		//instantiate existing managers.
 		for(KieReleaseId release : kieBaseXProcessInstanceDao.queryActiveKieReleases()) {
-			LOG.info("Rehydrating runtime manager for: "+release);
+			LOG.info("SETUP: Rehydrating runtime manager for: "+release);
 			getRuntimeManager(release);
 		}
 	}
@@ -97,7 +97,7 @@ public class RuntimeManagerBean {
 		//instantiate existing managers.
 		for(KieReleaseId release : kieBaseXProcessInstanceDao.queryActiveKieReleases()) {
 			if(!runtimeManagerCache.containsKey(release)) {
-				LOG.info("Rehydrating runtime manager for: "+release);
+				LOG.info("CACHE: Rehydrating runtime manager for: "+release);
 				getRuntimeManager(release);
 			}
 		}


### PR DESCRIPTION
now the Bean looks at the java:app/ name space first, then attempts to
load from java:global/ if a NameNotFoundException occurs. This addresses
remote and embedded jbpm-ee architectures.

Improved logging slightly in  RuntimeManagerBean
