### PR TITLE
Require hibernate flush data on commit

### DIFF
--- a/jbpm-ee-services/src/main/resources/META-INF/persistence.xml
+++ b/jbpm-ee-services/src/main/resources/META-INF/persistence.xml
@@ -69,6 +69,7 @@
 			<property name="hibernate.show_sql" value="false" />
 			<property name="hibernate.id.new_generator_mappings" value="false" />
 			<property name="hibernate.transaction.jta.platform" value="org.hibernate.service.jta.platform.internal.JBossAppServerJtaPlatform" />
+			<property name="hibernate.transaction.flush_before_completion" value="true"/>
 		</properties>
 
 	</persistence-unit>


### PR DESCRIPTION
Prevents a disposed ksession from being flush. This will cause a race condition based exception.
