### PR TITLE
Fix stackoverflow error

### DIFF
--- a/jbpm-ee-client/jbpm-ee-client-common/src/main/java/org/jbpm/ee/services/model/process/WorkItem.java
+++ b/jbpm-ee-client/jbpm-ee-client-common/src/main/java/org/jbpm/ee/services/model/process/WorkItem.java
@@ -104,7 +104,7 @@ public class WorkItem implements org.kie.api.runtime.process.WorkItem, Serializa
 
 	@Override
 	public Map<String, Object> getParameters() {
-		return this.getParameters();
+		return this.parameters;
 	}
 
 	@Override


### PR DESCRIPTION
Return the map instead of a recursive call to getParameters()
