### PR TITLE
WorkItemdefinition changes to support META-INF (logical) and the default location for this file in Business Central in BPMS6 beta

### DIFF
--- a/jbpm-ee-services/src/main/java/org/jbpm/ee/runtime/KieContainerEE.java
+++ b/jbpm-ee-services/src/main/java/org/jbpm/ee/runtime/KieContainerEE.java
@@ -63,8 +63,12 @@ public class KieContainerEE implements org.kie.api.runtime.KieContainer {
 
 	protected void refreshWorkItemDefinitionCache() { 
 		List<Map<String, Object>> definition = WorkItemDefinitionUtil.loadWorkItemDefinitions(getReleaseId(), "META-INF/WorkDefinitions.wid");
-		if(definition == null) {
-			return;
+		if(definition == null || definition.size() == 0) {
+			// also try this path, since Business Central in JBPM6 seems to put it here now by default
+			definition = WorkItemDefinitionUtil.loadWorkItemDefinitions(getReleaseId(), "WorkDefinitions.wid");
+			if (definition == null) {
+				return;
+			}
 		}
 		
 		//otherwise, populate.
@@ -83,7 +87,7 @@ public class KieContainerEE implements org.kie.api.runtime.KieContainer {
 				defaultHandler = getClassLoader().loadClass(defaultHandlerName);
 				WorkItemHandler instance = (WorkItemHandler)defaultHandler.newInstance();
 				this.workItemHandlers.put(handlerName, instance);
-			} catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+			} catch (Exception e) {
 				LOG.error("Handler ["+handlerName+"] unable to register class ["+defaultHandlerName+"]");
 			}
 		}


### PR DESCRIPTION
1. Made the workitemdefinition also load from /WorkDefinitions.wid (as this is the default in BusinessCentral in the BPMS6 beta)
2. Made the system catch Exception, as otherwise some of the default tasks may prevent a successful startup. Errors are still logged.
